### PR TITLE
fixed reload only file changed.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -137,7 +137,7 @@ class Server extends EventEmitter {
     setTimeout(
       this.send.bind(this, {
         command: 'reload',
-        path: filepath,
+        path: filepath.replace(/\\/g, '/'),
         liveCSS: this.config.applyCSSLive,
         liveImg: this.config.applyImageLive
       }),


### PR DESCRIPTION
Problem.

I found problem with atom on windows because windows use backslash.
example;
D;\website\style.css

After save .css,.js file livereload have been reload all .css ,.js on browser.

fix convert backslash to slash. for reload only  file changed.